### PR TITLE
Reduce CheckWin to 6 lines

### DIFF
--- a/CheckWin.py
+++ b/CheckWin.py
@@ -1,120 +1,14 @@
 def checkWin(move, board, player): # move: [x, y, z] AKA the address
-
    def check(xFunc, yFunc, zFunc):
       sumd = 0
       for i in range(4):
          sumd += board[xFunc(i)][yFunc(i)][zFunc(i)]
       return sumd == player * 4
-   
-   x = move[0]
-   y = move[1]
-   z = move[2]
-   
-   for (a = 0; a < 2; a++) {
-      for (b = 0; b < 2; b++) {
-         for (c = 0; c < 2; c++) {
-            
-         }
-      }
-   }
-   # z-check
-   if board[x][y] == [player, player, player, player]:
-       print("Player " + str(player) + " wins!")
-       return True
-
-   # x-check
-   if check(lambda i: i, lambda i: y, lambda i: z):
-      return True
-   
-   # y-check
-   if check(lambda i: x, lambda i: i, lambda i: z):
-      return True
-   
-   # diagonal check 1
-   if check(lambda i: i, lambda i: i, lambda i: z):
-      return True
-   
-   # diagonal check 2
-   if check(lambda i: i, lambda i: 3 - i, lambda i: z):
-      return True
-   
-   # diagonal check 3
-   if check(lambda i: x, lambda i: i, lambda i: i):
-      return True
-
-   # diagonal check 4
-   if check(lambda i: x, lambda i: 3 - i, lambda i: i):
-      return True
-   
-   
-   # diagonal check 5
-   if check(lambda i: i, lambda i: y, lambda i: i):
-      return True
-
-   
-   # diagonal check 6
-   if check(lambda i: 3 - i, lambda i: y, lambda i: i):
-      return True
-  
-   #Grand Diagonal Checks (4)
-
-
-   #GD check 1
-   if check(lambda i: i, lambda i: i, lambda i: i):
-      return True
-
-   #GD check 2
-   if check(lambda i: 3 - i, lambda i: i, lambda i: i):
-      return True
-
-   #GD check 3
-   if check(lambda i: i, lambda i: 3 - i, lambda i: i):
-      return True
-
-   #GD check 4
-   if check(lambda i: i, lambda i: i, lambda i: 3 - i):
-      return True
-
-   return False
-
-
-   '''
-   
-   
-   GD Check 4
-   thefunction(lambda x: x, lambda x: x, lambda x: 3-x)
-   
-   funcvtion whaterr i don't car eboayut ptuthon (x, y, z):
-     SUMD = 0
-      FOR I IN 0 TO 3
-           SUMD += board[x(I), y(I), z(I)]
-      
-         
-  def check_diagonals(a,b,c):
-   sumd = 0
-   for i in range(4):
-           sumd1= board[i][i][z]
-           if sumd1= player*4:
-               print("Player " + str(player) + " wins!")
-               return True
-            else
-               return False
-
-  sum = 0
-  for i in range(4)
-   sum = check_axes(i,y,z)
-   if sum = player * 4:
-           print ("Player" + str(player) + " wins!")
-           return True
-
-
-  def check_axes (x, y, z, sum):
-      return sum + board[x][y][z]
-      
-      
-      
-      
-
-
-
-   '''
+   xs = [lamda i:move[0], lamda i: i, lamda i:3-i]
+   ys = [lamda i:move[1], lamda i: i, lamda i:3-i]
+   zs = [lamda i:move[2], lamda i:i, lamda i:3-i]
+   for (a in range(3)):
+      for (b in range(3)):
+         for (c in range(3)):
+            if check(xs[a], ys[b], zs[c]):
+             return True

--- a/CheckWin.py
+++ b/CheckWin.py
@@ -9,7 +9,14 @@ def checkWin(move, board, player): # move: [x, y, z] AKA the address
    x = move[0]
    y = move[1]
    z = move[2]
-
+   
+   for (a = 0; a < 2; a++) {
+      for (b = 0; b < 2; b++) {
+         for (c = 0; c < 2; c++) {
+            
+         }
+      }
+   }
    # z-check
    if board[x][y] == [player, player, player, player]:
        print("Player " + str(player) + " wins!")


### PR DESCRIPTION
This version of Tetra Tic-Tac-Toe aims to reduce the CheckWin file and function to a mere 6 lines by using lambdas, loops, and arrays. 
**Note: This assumes that the current "sloppy" version works and only needs to be changed for human-readability purposes.**
```   
# x-check
if check(lambda i: i, lambda i: y, lambda i: z):
   return True
# y-check
if check(lambda i: x, lambda i: i, lambda i: z):
   return True
```
As in the sample code above written by @reflectronic and @David-Volchonok , each argument takes the format `lamda i: [some value]` where [some value] is
For argument 1, x, i, or 3-i
For argument 2, y, i, or 3-i
For argument 3, z, i or 3-i

Therefore, in order to go through all the combinations, one can set an array with these values and loop through them in a triple-nested for loop. 
`xs = [lamda i:x, lamda i: i, lamda i:3-i]`
`ys=  [lamda i:y, lamda i: i, lamda i:3-i]`
`zs = [lamda i:z, lamda i:i, lamda i:3-i]`
```for (a in range(3)):
  for (b in range(3)):
   for (c in range(3)):
    if(check(xs[a], ys[b], zs[c])):
     return True
return False
```